### PR TITLE
Test for subscription propagation

### DIFF
--- a/latency.go
+++ b/latency.go
@@ -57,15 +57,16 @@ func waitForRoute(pnc, snc *nats.Conn) {
 
 	// Periodically send messages until the test subscription receives
 	// a message.  Allow for two seconds.
-	for i := 0; atomic.LoadInt32(&routed) == 0 && i < 200; i++ {
-		time.Sleep(10 * time.Millisecond)
+	start := time.Now()
+	for atomic.LoadInt32(&routed) == 0 {
+		if time.Since(start) > (time.Second * 2) {
+			log.Fatalf("Couldn't receive end-to-end test message.")
+		}
 		if err = pnc.Publish(subject, nil); err != nil {
 			log.Fatalf("Couldn't publish to test subject %s:  %v", subject, err)
 		}
 		pnc.Flush()
-	}
-	if atomic.LoadInt32(&routed) == 0 {
-		log.Fatalf("Couldn't receive end-to-end test message.")
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 

--- a/latency.go
+++ b/latency.go
@@ -65,7 +65,6 @@ func waitForRoute(pnc, snc *nats.Conn) {
 		if err = pnc.Publish(subject, nil); err != nil {
 			log.Fatalf("Couldn't publish to test subject %s:  %v", subject, err)
 		}
-		pnc.Flush()
 		time.Sleep(10 * time.Millisecond)
 	}
 }

--- a/latency.go
+++ b/latency.go
@@ -131,7 +131,7 @@ func main() {
 	// Make sure interest is set for subscribe before publish since a different connection.
 	c2.Flush()
 
-	// wait for routes to be estabilished so we get every message
+	// wait for routes to be established so we get every message
 	waitForRoute(c1, c2)
 
 	log.Printf("Message Payload: %v\n", byteSize(MsgSize))

--- a/latency.go
+++ b/latency.go
@@ -9,7 +9,9 @@ import (
 	"log"
 	"math"
 	"sort"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/codahale/hdrhistogram"
@@ -28,6 +30,43 @@ var (
 
 func usage() {
 	log.Fatalf("Usage: latency [-sa serverA] [-sb serverB] [-sz msgSize] [-tr msgs/sec] [-tt testTime] [-hist <file>]\n")
+}
+
+// waitForRoute tests a subscription in the server to ensure subject interest
+// has been propagated between servers.  Otherwise, we may miss early messages
+// when testing with clustered servers and the test will hang.
+func waitForRoute(pnc, snc *nats.Conn) {
+
+	// No need to continue if using one server
+	if strings.Compare(pnc.ConnectedServerId(), snc.ConnectedServerId()) == 0 {
+		return
+	}
+
+	// Setup a test subscription to let us know when a message has been received.
+	// Use a new inbox subject as to not skew results
+	var routed int32
+	subject := nats.NewInbox()
+	sub, err := snc.Subscribe(subject, func(msg *nats.Msg) {
+		atomic.AddInt32(&routed, 1)
+	})
+	if err != nil {
+		log.Fatalf("Couldn't subscribe to test subject %s: %v", subject, err)
+	}
+	defer sub.Unsubscribe()
+	snc.Flush()
+
+	// Periodically send messages until the test subscription receives
+	// a message.  Allow for two seconds.
+	for i := 0; atomic.LoadInt32(&routed) == 0 && i < 200; i++ {
+		time.Sleep(10 * time.Millisecond)
+		if err = pnc.Publish(subject, nil); err != nil {
+			log.Fatalf("Couldn't publish to test subject %s:  %v", subject, err)
+		}
+		pnc.Flush()
+	}
+	if atomic.LoadInt32(&routed) == 0 {
+		log.Fatalf("Couldn't receive end-to-end test message.")
+	}
 }
 
 func main() {
@@ -54,10 +93,10 @@ func main() {
 	}
 	c2, err := nats.Connect(ServerB)
 	if err != nil {
-		log.Fatalf("Could not connect to ServerA: %v", err)
+		log.Fatalf("Could not connect to ServerB: %v", err)
 	}
 
-	// Do some qiuck RTT calculations
+	// Do some quick RTT calculations
 	log.Println("==============================")
 	now := time.Now()
 	c1.Flush()
@@ -92,8 +131,8 @@ func main() {
 	// Make sure interest is set for subscribe before publish since a different connection.
 	c2.Flush()
 
-	// Allow time for subscription propagation when using clustered servers.
-	time.Sleep(1 * time.Second)
+	// wait for routes to be estabilished so we get every message
+	waitForRoute(c1, c2)
 
 	log.Printf("Message Payload: %v\n", byteSize(MsgSize))
 	log.Printf("Target Duration: %v\n", TestDuration)

--- a/latency.go
+++ b/latency.go
@@ -92,6 +92,9 @@ func main() {
 	// Make sure interest is set for subscribe before publish since a different connection.
 	c2.Flush()
 
+	// Allow time for subscription propagation when using clustered servers.
+	time.Sleep(1 * time.Second)
+
 	log.Printf("Message Payload: %v\n", byteSize(MsgSize))
 	log.Printf("Target Duration: %v\n", TestDuration)
 	log.Printf("Target Msgs/Sec: %v\n", TargetPubRate)


### PR DESCRIPTION
Sometimes tests with clustered servers hang because the first message was sent before subscription interest was propagated.  This uses a test subscription to check that `serverb` has propagated subject interest to `servera` before starting the test.

Signed-off-by: Colin Sullivan <colin@synadia.com>