### PR TITLE
Updates from user requests

### DIFF
--- a/latency.go
+++ b/latency.go
@@ -288,7 +288,7 @@ func fmtDur(t time.Duration) time.Duration {
 	return t.Truncate(time.Millisecond)
 }
 
-// writeRawFile create a file with a list of recorded latency
+// writeRawFile creates a file with a list of recorded latency
 // measurements, one per line.
 func writeRawFile(filePath string, values []time.Duration) error {
 	f, err := os.Create(filePath)


### PR DESCRIPTION
We've had requests to:

* Display wall clock time at end of publishing and end of subscribing
* Display min/max latency
* Save the raw data (unsorted)
* Extend the histogram to always include maximum latency values

Signed-off-by: Colin Sullivan <colin@synadia.com>